### PR TITLE
generateTranslations: write out `data` not `defaultMessages`

### DIFF
--- a/lib/generate-translation.js
+++ b/lib/generate-translation.js
@@ -23,7 +23,7 @@ function generateTranslation(attributes, callback) {
     function(callback) {
       var data = {};
       data[defaultLocale] = defaultMessages;
-      fs.writeFile(filepath, JSON.stringify(defaultMessages, null, "  "), callback);
+      fs.writeFile(filepath, JSON.stringify(data, null, "  "), callback);
     }
   ], callback);
 }


### PR DESCRIPTION
`generateTranslations` writes out the wrong message format; it writes:

``` json
{ "foo": "foo" }
```

instead of

``` json
{ "en": { "foo": "foo" } }
```

Since the `data` object is already created (and not used), I assume this was just an error.
