### PR TITLE
transform: support Babel6

### DIFF
--- a/lib/extract-transforms/babel-globalize2-default-into-globalize.js
+++ b/lib/extract-transforms/babel-globalize2-default-into-globalize.js
@@ -1,4 +1,5 @@
 var esprima = require( "esprima" );
+var syntaxUtils = require( "../util/syntax" );
 
 var Syntax = esprima.Syntax;
 
@@ -13,8 +14,7 @@ module.exports = {
 			node.callee.object.type === Syntax.MemberExpression &&
 			node.callee.object.object.type === Syntax.Identifier &&
 			node.callee.object.object.name === "_globalize2" &&
-			node.callee.object.property.type === Syntax.Literal &&
-			node.callee.object.property.value === "default";
+			syntaxUtils.isDefaultProperty(node.callee.object.property);
 	},
 
 	transform: function( node ) {

--- a/lib/extract-transforms/babel-react2-default-into-react.js
+++ b/lib/extract-transforms/babel-react2-default-into-react.js
@@ -1,4 +1,5 @@
 var esprima = require("esprima");
+var syntaxUtils = require( "../util/syntax" );
 
 var Syntax = esprima.Syntax;
 
@@ -14,10 +15,10 @@ module.exports = {
       node.callee.object.object.type === Syntax.Identifier &&
       (
        node.callee.object.object.name === "_react2" ||
-       node.callee.object.object.name === "_reactAddons2"
+       node.callee.object.object.name === "_reactAddons2" ||
+       node.callee.object.object.name === "_addons2"
       ) &&
-      node.callee.object.property.type === Syntax.Literal &&
-      node.callee.object.property.value === "default";
+      syntaxUtils.isDefaultProperty(node.callee.object.property);
   },
 
   transform: function(node) {

--- a/lib/util/syntax.js
+++ b/lib/util/syntax.js
@@ -1,0 +1,14 @@
+var esprima = require("esprima");
+
+var Syntax = esprima.Syntax;
+
+/**
+ * Utilities for dealing with syntax trees
+ */
+
+module.exports = {
+	isDefaultProperty: function(property) {
+		return (property.type === Syntax.Literal && property.value === "default") ||
+			(property.type === Syntax.Identifier && property.name === "default");
+	}
+};

--- a/package.json
+++ b/package.json
@@ -43,7 +43,9 @@
   },
   "devDependencies": {
     "async": "0.9.0",
-    "babel": "^5.6.14",
+    "babel-core": "^6.4.5",
+    "babel-preset-es2015": "^6.3.13",
+    "babel-preset-react": "^6.3.13",
     "chai": "1.10.x",
     "jshint": "2.6.x",
     "mocha": "2.1.0"

--- a/test/index.js
+++ b/test/index.js
@@ -1,11 +1,14 @@
-var babel = require("babel");
+var babel = require("babel-core");
 var fs = require("fs");
 var esprima = require("esprima");
 var expect = require("chai").expect;
 var reactGlobalizeCompiler = require("../index");
 
 function getFixtureAst(filename) {
-  return esprima.parse(babel.transform(fs.readFileSync(__dirname + "/fixtures/" + filename)).code);
+  var code = fs.readFileSync(__dirname + "/fixtures/" + filename);
+  var options = { presets: ["es2015", "react"] };
+
+  return esprima.parse( babel.transform(code, options).code );
 }
 
 var fixtures = {


### PR DESCRIPTION
Babel 6 outputs `module.default` rather than `module["default"]` for
default exports. This patch supports both formats.

See also jquery-support/globalize-compiler#12
