### PR TITLE
Fix for E_MISSING_MESSAGE: Missing required message content

### DIFF
--- a/lib/extract-default-messages.js
+++ b/lib/extract-default-messages.js
@@ -59,7 +59,16 @@ function extractor(input) {
       return visitor.test(node);
     }).reduce(function(defaultMessages, visitor) {
       var aux = visitor.getDefaultMessage(node);
-      defaultMessages[aux.path] = aux.message;
+      
+      var pathArray = aux.path.split("/");
+      var leaf = pathArray.pop();
+      var messageObj = defaultMessages;
+      pathArray.forEach( function(path) {
+        messageObj[path] = messageObj[path] || {};
+        messageObj = messageObj[path];
+      });
+      messageObj[leaf] = aux.message;
+      
       return defaultMessages;
     }, {}));
   });


### PR DESCRIPTION
Don't flatten json object for default messages with path length > 1 or else Globalize won't be able to find them later.
