### PR TITLE
Sync compiler behavior with development mode

### DIFF
--- a/lib/extract-default-messages-visitors/react-globalize-format-message.js
+++ b/lib/extract-default-messages-visitors/react-globalize-format-message.js
@@ -25,6 +25,10 @@ module.exports = {
     var message, path, scope;
 
     message = eval("(" + escodegen.generate(node.arguments[2]) + ")");
+
+    if ((path = getObjectKey(node.arguments[1], "path"))) {
+      path = eval("(" + escodegen.generate(path.value) + ")");
+    } else
     path = sanitizePath(message);
 
     if (scope = getObjectKey(node.arguments[1], "scope")) {

--- a/lib/extract-default-messages.js
+++ b/lib/extract-default-messages.js
@@ -83,7 +83,7 @@ function extractor(input) {
 
   // Traverse AST and collect default messages.
   traverse(ast, function(node) {
-    defaultMessages = merge(defaultMessages,visitors.filter(function(visitor) {
+    defaultMessages = merge(defaultMessages, visitors.filter(function(visitor) {
       return visitor.test(node);
     }).reduce(function(defaultMessages, visitor) {
       var aux = visitor.getDefaultMessage(node);

--- a/lib/extract-default-messages.js
+++ b/lib/extract-default-messages.js
@@ -14,6 +14,34 @@ function traverse(ast, iterate) {
   });
 }
 
+// Returns new deeply merged JSON.
+//
+// Eg.
+// merge({a: {b: 1, c: 2}}, {a: {b: 3, d: 4}})
+// -> {a: {b: 3, c: 2, d: 4}}
+//
+// Borrowed from cldrjs.
+function merge() {
+  var destination = {};
+  var sources = [].slice.call(arguments, 0);
+  sources.forEach(function(source) {
+    var prop;
+    for (prop in source) {
+      if (prop in destination && Array.isArray(destination[prop])) {
+        // Clone Arrays
+        destination[prop] = source[prop].slice(0);
+      } else if (prop in destination && typeof destination[prop] === "object") {
+        // Merge Objects
+        destination[prop] = merge(destination[prop], source[prop]);
+      } else {
+        // Set new values
+        destination[prop] = source[prop];
+      }
+    }
+  });
+  return destination;
+}
+
 /**
  * extractor(filename|fileContent|ast)
  *
@@ -55,12 +83,13 @@ function extractor(input) {
 
   // Traverse AST and collect default messages.
   traverse(ast, function(node) {
-    extend(defaultMessages, visitors.filter(function(visitor) {
+    defaultMessages = merge(defaultMessages,visitors.filter(function(visitor) {
       return visitor.test(node);
     }).reduce(function(defaultMessages, visitor) {
       var aux = visitor.getDefaultMessage(node);
-      defaultMessages[aux.path] = aux.message;
-      return defaultMessages;
+      return aux.path.split("/").reduceRight(function(acc, property) {
+        return { [property]: acc };
+      }, aux.message);
     }, {}));
   });
 

--- a/lib/extract-visitors/format-message.js
+++ b/lib/extract-visitors/format-message.js
@@ -22,8 +22,13 @@ module.exports = {
     /*jslint evil: true */
     var path, scope;
 
-    path = eval("(" + escodegen.generate(node.arguments[2]) + ")");
-    path = sanitizePath(path);
+    if ((path = getObjectKey(node.arguments[1], "path"))) {
+      path = eval("(" + escodegen.generate(path.value) + ")");
+    } else {
+      path = eval("(" + escodegen.generate(node.arguments[2]) + ")");
+      path = sanitizePath(path);
+      
+    }
 
     if (scope = getObjectKey(node.arguments[1], "scope")) {
       scope = eval("(" + escodegen.generate(scope.value) + ")");


### PR DESCRIPTION
Development mode works accordingly to the documentation, production mode was lagging behind.
This commits enable path parameter in FormatMessage and treat the defaultMessage as "default" not primary value for the development locale.